### PR TITLE
feature: Добавил шаблоны-формы для issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_rule.yaml
+++ b/.github/ISSUE_TEMPLATE/add_rule.yaml
@@ -1,0 +1,37 @@
+name: Добавление правила
+description: Добавление нового правила в style guide
+labels: ["discussion", "add"]
+body:
+  - type: input
+    id: rule_title
+    attributes:
+      label: Новое правило
+      description: Заголовок нового правила
+      placeholder: ex. Форматирование лямбда-выражений
+    validations:
+      required: true
+
+  - type: textarea
+    id: rule_body
+    attributes:
+      label: Описание правила
+      description: Развернутое описание правила
+      placeholder: ex. При написании лямбда-выражения более чем в одну строку всегда использовать именованный аргумент, вместо `it`
+    validations:
+      required: false
+      
+  - type: textarea
+    id: rule_code_ex_before
+    attributes:
+      label: Пример плохого кода
+      render: Kotlin
+    validations:
+      required: false
+
+  - type: textarea
+    id: rule_code_ex_after
+    attributes:
+      label: Пример хорошего кода
+      render: Kotlin
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/change_rule.yaml
+++ b/.github/ISSUE_TEMPLATE/change_rule.yaml
@@ -1,0 +1,45 @@
+name: Изменение правила
+description: Изменение существующего правила из style guide
+labels: ["discussion", "change"]
+body:
+  - type: input
+    id: rule_link
+    attributes:
+      label: Ссылка на существующее правило
+    validations:
+      required: true
+
+  - type: dropdown
+    id: rule_type
+    attributes:
+      label: Тип
+      options:
+        - Удаление
+        - Изменение
+    validations:
+      required: true
+
+  - type: textarea
+    id: rule_motivation_and_changes
+    attributes:
+      label: Мотивация и список изменений
+      description: Почему и как хочется изменить правило?
+      placeholder: ex. С приходом Compose лямбды теперь передаём в параметрах чаще и необходимость явно прописывать invoke, как мне кажется, только усложняет чтение кода.
+    validations:
+      required: true
+      
+  - type: textarea
+    id: rule_code_ex_before
+    attributes:
+      label: Пример плохого кода
+      render: Kotlin
+    validations:
+      required: false
+
+  - type: textarea
+    id: rule_code_ex_after
+    attributes:
+      label: Пример хорошего кода
+      render: Kotlin
+    validations:
+      required: true


### PR DESCRIPTION
Проверить как это работает можно вот в этом репе: https://github.com/sonulen/issue_form_check

А почитать о формах:

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema