### PR TITLE
Убрать требование про пустые строки в when.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,18 +208,18 @@ data class UserInfo (
 ```kotlin
 return if (condition) foo() else bar()
 ```
-- В операторе `when` ветки, состоящие более чем из одной строки, обрамлять фигурными скобками и отделять от других case-веток пустыми строками сверху и снизу.
+- В операторе `when` ветки, состоящие более чем из одной строки, обрамлять фигурными скобками:
 ```kotlin
-when (feed.type) {
-    FeedType.PERSONAL -> startPersonalFeedScreen()
-    
-    FeedType.SUM -> {
-        showSumLayout()
-        hideProgressBar()
+when (whenType) {
+    WhenType.ONE -> someMethod()
+    WhenType.MANY -> {
+        someMethod()
+        anotherMethod()
     }
-    
-    FeedType.CARD -> startCardFeedScreen()
-    else -> showError() 
+    WhenType.CHAIN -> {
+        someList()
+            .map() { ... }
+    }
 }
 ```
 


### PR DESCRIPTION
Пустые строки между block body ветками when не дают пользы, тк закрывающая скобка и четко ярко всё отделяет. 

Когда-то давно, кажется, в Kotlin Coding Conventions было правило про пустые строки. Но сейчас его нет. 
[Есть только](https://kotlinlang.org/docs/coding-conventions.html#control-flow-statements) про то, что следует отделять пустой строкой, если ветка НЕ выделенная фигурными скобками стала многострочной. 
<img width="779" alt="image (4)" src="https://user-images.githubusercontent.com/1622073/165125233-c5899734-7c27-4656-953a-872f12012065.png">
Это правило имеет смысл, но это не общее требование пустых строк между блоками, а только если многострочное выражение, чего у нас не может быть из-за оставшейся части правила о том, чтобы 

> ветки, состоящие более чем из одной строки, обрамлять фигурными скобками

А значит к нашему случаю не применимо. 

Предлагаю от требования о пустых строках избавиться.


